### PR TITLE
fix set-output deprecations

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,5 +53,5 @@ runs:
         mv "${artifact}" "${output_path}"
 
         artifact_url="${output_path}/${artifact}"
-        echo "::set-output name=artifact_url::$artifact_url"
+        echo "artifact_url=$artifact_url" >> $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
[Github has deprecated `set-output`](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). This PR replaces `set-output` usage with the new recommended pattern.

Installed and ran `actionlint` to assist with verifying. Otherwise these changes need to run in actions to be tested.